### PR TITLE
Fix errors not getting reported

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Pipeline
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
         include:
           - os: ubuntu-latest
             go-build: ~/.cache/go-build
-    name: ${{ matrix.os }} @ Go ${{ matrix.go }}
+    name: Tests on ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: on

--- a/example/main.go
+++ b/example/main.go
@@ -14,7 +14,7 @@ func main() {
 	// roll.SetEnvironment("production") // defaults to "development"
 
 	r := gin.Default()
-	r.Use(ginrollbar.PanicLogs(false, ""))
+	r.Use(ginrollbar.LogRequests(false, false, ""))
 
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal(err)

--- a/ginrollbar_test.go
+++ b/ginrollbar_test.go
@@ -11,81 +11,206 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLogRequests(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	router.Use(func(c *gin.Context) {
-		defer func() {
-			if err := recover(); err != nil {
-				c.AbortWithStatus(http.StatusInternalServerError)
-			}
-		}()
-		c.Next()
-	})
+func TestLogPanicsToRollbar(t *testing.T) {
 	testError := &gin.Error{
 		Err:  errors.New("test error"),
 		Type: gin.ErrorTypePublic,
 	}
 	testError.SetMeta("some data") //nolint:errcheck
-	router.Use(PanicLogs(false, ""))
-	router.GET("/", func(c *gin.Context) {
-		_ = c.Error(testError)
-		_ = c.Error(testError)
-		panic("occurs panic")
-	})
 
-	RollbarCritical = func(interfaces ...interface{}) {
-		if err, ok := interfaces[0].(error); ok {
-			assert.Equal(t, "occurs panic", err.Error())
-		} else {
-			t.Error("interfaces[0] should be error")
-		}
-		if request, ok := interfaces[1].(*http.Request); ok {
-			assert.Equal(t, "/", request.RequestURI)
-		} else {
-			t.Error("interfaces[1] should be *http.Request")
-		}
-		if level, ok := interfaces[2].(int); ok {
-			assert.Equal(t, 3, level)
-		} else {
-			t.Error("interfaces[2] should be int")
-		}
-		if metaData, ok := interfaces[3].(map[string]interface{}); ok {
-			fmt.Printf("%+v", metaData)
-			endpoint, _ := metaData["endpoint"].(string)
-			assert.Equal(t, "/", endpoint)
-		} else {
-			t.Error("interfaces[3] should be map[string]interface{}")
-		}
+	type args struct {
+		onlyPanics         bool
+		handler            gin.HandlerFunc
+		expectedErrorCalls int
+		expectedPanicCalls int
+		expectedHttpStatus int
 	}
 
-	errorCalls := 0
-	RollbarError = func(interfaces ...interface{}) {
-		errorCalls++
-		if err, ok := interfaces[0].(error); ok {
-			assert.Equal(t, testError.Err.Error(), err.Error())
-		} else {
-			t.Error("interfaces[0] should be error")
-		}
-		if request, ok := interfaces[1].(*http.Request); ok {
-			assert.Equal(t, "/", request.RequestURI)
-		} else {
-			t.Error("interfaces[1] should be *http.Request")
-		}
-		if metaData, ok := interfaces[2].(map[string]interface{}); ok {
-			endpoint, _ := metaData["endpoint"].(string)
-			assert.Equal(t, "/", endpoint)
-			meta, _ := metaData["meta"].(string)
-			assert.Equal(t, "some data", meta)
-		} else {
-			t.Error("interfaces[2] should be map[string]interface{}")
-		}
+	tests := []struct {
+		name string
+		args args
+	}{
+		// Tests with onlyPanics set to true
+		{
+			name: "setting onlyPanics should not log errors when present and should log panic when present",
+			args: args{
+				onlyPanics: true,
+				handler: func(c *gin.Context) {
+					_ = c.Error(testError)
+					_ = c.Error(testError)
+					panic("occurs panic")
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 1,
+				expectedHttpStatus: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "setting onlyPanics should log only panic when present",
+			args: args{
+				onlyPanics: true,
+				handler: func(c *gin.Context) {
+					panic("occurs panic")
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 1,
+				expectedHttpStatus: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "setting onlyPanics should not log anything when only errors are present",
+			args: args{
+				onlyPanics: true,
+				handler: func(c *gin.Context) {
+					_ = c.Error(testError)
+					_ = c.Error(testError)
+					c.AbortWithStatus(http.StatusBadRequest)
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 0,
+				expectedHttpStatus: http.StatusBadRequest,
+			},
+		},
+		{
+			name: "setting onlyPanics should not log anything when neither errors nor panics are present",
+			args: args{
+				onlyPanics: true,
+				handler: func(c *gin.Context) {
+					c.Status(http.StatusOK)
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 0,
+				expectedHttpStatus: http.StatusOK,
+			},
+		},
+		// Tests with onlyPanics set to false
+		{
+			name: "not setting onlyPanics should log errors when present and should log panic when present",
+			args: args{
+				onlyPanics: false,
+				handler: func(c *gin.Context) {
+					_ = c.Error(testError)
+					_ = c.Error(testError)
+					panic("occurs panic")
+				},
+				expectedErrorCalls: 2,
+				expectedPanicCalls: 1,
+				expectedHttpStatus: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "not setting onlyPanics should log only panics are present",
+			args: args{
+				onlyPanics: false,
+				handler: func(c *gin.Context) {
+					panic("occurs panic")
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 1,
+				expectedHttpStatus: http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "not setting onlyPanics should log errors when only errors are present",
+			args: args{
+				onlyPanics: false,
+				handler: func(c *gin.Context) {
+					_ = c.Error(testError)
+					_ = c.Error(testError)
+					c.AbortWithStatus(http.StatusBadRequest)
+				},
+				expectedErrorCalls: 2,
+				expectedPanicCalls: 0,
+				expectedHttpStatus: http.StatusBadRequest,
+			},
+		},
+		{
+			name: "not setting onlyPanics should not log anything when neither errors nor panics are present",
+			args: args{
+				onlyPanics: false,
+				handler: func(c *gin.Context) {
+					c.Status(http.StatusOK)
+				},
+				expectedErrorCalls: 0,
+				expectedPanicCalls: 0,
+				expectedHttpStatus: http.StatusOK,
+			},
+		},
 	}
 
-	w := performRequest("GET", "/", router)
+	for _, tt := range tests {
+		panicCalls := 0
+		RollbarCritical = func(interfaces ...interface{}) {
+			panicCalls++
+			if err, ok := interfaces[0].(error); ok {
+				assert.Equal(t, "occurs panic", err.Error())
+			} else {
+				t.Error("interfaces[0] should be error")
+			}
+			if request, ok := interfaces[1].(*http.Request); ok {
+				assert.Equal(t, "/", request.RequestURI)
+			} else {
+				t.Error("interfaces[1] should be *http.Request")
+			}
+			if level, ok := interfaces[2].(int); ok {
+				assert.Equal(t, 3, level)
+			} else {
+				t.Error("interfaces[2] should be int")
+			}
+			if metaData, ok := interfaces[3].(map[string]interface{}); ok {
+				fmt.Printf("%+v", metaData)
+				endpoint, _ := metaData["endpoint"].(string)
+				assert.Equal(t, "/", endpoint)
+			} else {
+				t.Error("interfaces[3] should be map[string]interface{}")
+			}
+		}
 
-	assert.Equal(t, 500, w.Code, "http status code")
-	assert.Equal(t, 2, errorCalls, "Calls to RollbarError")
+		errorCalls := 0
+		RollbarError = func(interfaces ...interface{}) {
+			errorCalls++
+			if err, ok := interfaces[0].(error); ok {
+				assert.Equal(t, testError.Err.Error(), err.Error())
+			} else {
+				t.Error("interfaces[0] should be error")
+			}
+			if request, ok := interfaces[1].(*http.Request); ok {
+				assert.Equal(t, "/", request.RequestURI)
+			} else {
+				t.Error("interfaces[1] should be *http.Request")
+			}
+			if metaData, ok := interfaces[2].(map[string]interface{}); ok {
+				endpoint, _ := metaData["endpoint"].(string)
+				assert.Equal(t, "/", endpoint)
+				meta, _ := metaData["meta"].(string)
+				assert.Equal(t, "some data", meta)
+			} else {
+				t.Error("interfaces[2] should be map[string]interface{}")
+			}
+		}
+
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			defer func() {
+				if err := recover(); err != nil {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+			}()
+			c.Next()
+		})
+
+		router.Use(LogRequests(tt.args.onlyPanics, false, ""))
+		router.GET("/", tt.args.handler)
+
+		t.Run(tt.name, func(t *testing.T) {
+			w := performRequest("GET", "/", router)
+
+			assert.Equal(t, tt.args.expectedHttpStatus, w.Code, "http status code")
+			assert.Equal(t, tt.args.expectedErrorCalls, errorCalls, "Calls to RollbarError")
+			assert.Equal(t, tt.args.expectedPanicCalls, panicCalls, "Calls to RollbarCritical")
+		})
+	}
 }
 
 func performRequest(method, target string, router *gin.Engine) *httptest.ResponseRecorder {

--- a/ginrollbar_test.go
+++ b/ginrollbar_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLogPanicsToRollbar(t *testing.T) {
+func TestLogRequests(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.Use(func(c *gin.Context) {


### PR DESCRIPTION
- Change function name from `PanicLogs` to `LogRequests` to reflect that we're logging request items, errors and panics, to Rollbar
- Report errors before handling panics, if either exist, so that we can continue to re-panic after handling the panic
- Add more verbose tests to make sure we're calling `RollbarCritical` and `RollbarError` as expected when, for both `onlyPanics` true and false, we have the following situations:
  - Panic is present
  - Errors are present
  - Both are present
  - Neither are present